### PR TITLE
fix: import useFormatters in SmartNumberInput

### DIFF
--- a/src/components/SmartNumberInput.tsx
+++ b/src/components/SmartNumberInput.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { AlertCircle, Info, Copy, Check } from 'lucide-react';
-import { parseNumberInput, formatForInput, validateKpiTarget, getKpiPlaceholder, logNumberInputTelemetry, KPI_CONFIGS, parsePercentToBps, formatPercentFromBps } from '../utils/numberFormatting';
+import { parseNumberInput, formatForInput, validateKpiTarget, getKpiPlaceholder, logNumberInputTelemetry, KPI_CONFIGS, parsePercentToBps } from '../utils/numberFormatting';
 import { parseSmartNumber } from '../utils/formatters';
+import { useFormatters } from '../hooks/useFormatters';
 
 interface SmartNumberInputProps {
   kpi: string;


### PR DESCRIPTION
## Summary
- fix ReferenceError by importing `useFormatters` in `SmartNumberInput`

## Testing
- `npm run lint` *(fails: Users is defined but never used, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5bbe4be94832e8173309a4c81359d