### PR TITLE
fix: import sample campaigns and clean unused imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { useMediaSummaryData } from './hooks/useMediaSummaryData';
 import { calculateScenarioMetrics, formatCurrency } from './utils/calculations';
 import { exportToCsv } from './utils/export';
 import { Campaign } from './types/campaign';
-import { sampleDeliverables } from './utils/mockData';
+import { sampleDeliverables, sampleCampaigns } from './utils/mockData';
 
 function App() {
   const [allCampaigns, setAllCampaigns] = useState<Campaign[]>(sampleCampaigns);

--- a/src/components/CampaignCard.tsx
+++ b/src/components/CampaignCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Calendar, Users, FileText, MessageCircle, Paperclip, AlertTriangle, Clock, CheckCircle, ArrowRight } from 'lucide-react';
+import { Calendar, MessageCircle, Paperclip, AlertTriangle } from 'lucide-react';
 import { Campaign } from '../types/campaign';
-import { calculateScenarioMetrics, formatCurrency, formatNumber } from '../utils/calculations';
+import { calculateScenarioMetrics } from '../utils/calculations';
 import { useFormatters } from '../hooks/useFormatters';
 
 interface CampaignCardProps {


### PR DESCRIPTION
## Summary
- import sampleCampaigns into App to provide initial data
- remove unused icon and formatter imports in CampaignCard to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6282e7ee4832e9336e53411c47719