### PR TITLE
Add welcome landing page with basic routing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,36 @@
-import { StrictMode } from 'react';
+import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import LoginPage from './pages/LoginPage';
+import WelcomePage from './pages/WelcomePage';
 import './index.css';
+
+function Router() {
+  const [path, setPath] = useState(window.location.pathname);
+
+  useEffect(() => {
+    const handlePopState = () => setPath(window.location.pathname);
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  const navigate = (to: string) => {
+    window.history.pushState({}, '', to);
+    setPath(to);
+  };
+
+  switch (path) {
+    case '/welcome':
+      return <WelcomePage navigate={navigate} />;
+    case '/dashboard':
+      return <App />;
+    default:
+      return <LoginPage navigate={navigate} />;
+  }
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Router />
   </StrictMode>
 );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,24 @@
+interface LoginPageProps {
+  navigate: (path: string) => void;
+}
+
+export default function LoginPage({ navigate }: LoginPageProps) {
+  const handleLogin = () => {
+    navigate('/welcome');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50 p-4">
+      <div className="w-full max-w-md bg-white rounded-lg shadow p-8 space-y-6">
+        <h1 className="text-2xl font-bold text-center text-gray-900">Login</h1>
+        <button
+          type="button"
+          onClick={handleLogin}
+          className="w-full px-4 py-2 text-white bg-primary-600 hover:bg-primary-700 rounded-md"
+        >
+          Sign In
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/WelcomePage.tsx
+++ b/src/pages/WelcomePage.tsx
@@ -1,0 +1,27 @@
+interface WelcomePageProps {
+  navigate: (path: string) => void;
+}
+
+export default function WelcomePage({ navigate }: WelcomePageProps) {
+  const handleProceed = () => {
+    navigate('/dashboard');
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50 p-4">
+      <div className="w-full max-w-md bg-white rounded-lg shadow p-8 space-y-6 text-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Welcome!</h1>
+          <p className="mt-2 text-gray-600">You have successfully logged in.</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleProceed}
+          className="w-full px-4 py-2 text-white bg-primary-600 hover:bg-primary-700 rounded-md"
+        >
+          Go to Dashboard
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple login and welcome pages
- implement lightweight history-based router
- allow navigation from login to welcome then dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b62a9f01d0832e9727ddcd345c12fd