### PR TITLE
feat: add Supabase login page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
     "lucide-react": "^0.542.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useMemo } from 'react';
+import { createClient } from '@supabase/supabase-js';
+import { Loader2 } from 'lucide-react';
+
+const LoginPage: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const supabase = useMemo(
+    () =>
+      createClient(
+        import.meta.env.VITE_SUPABASE_URL!,
+        import.meta.env.VITE_SUPABASE_ANON_KEY!,
+        { auth: { persistSession: rememberMe } }
+      ),
+    [rememberMe]
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div
+      className="min-h-screen bg-cover bg-center flex items-center justify-center px-4 sm:px-6 lg:px-8"
+      style={{
+        backgroundImage:
+          "url('/20250830_1808_Energetic%20Radiant%20Glow_simple_compose_01k3ygawskfnc8tbkrkmcj10q1.png')",
+      }}
+    >
+      <div className="w-full max-w-sm sm:max-w-md bg-white/80 backdrop-blur rounded-lg shadow-xl p-6 sm:p-8">
+        <img
+          src="/negotiator_logo_gradient.png"
+          alt="Negotiator"
+          className="h-12 w-auto mx-auto mb-6"
+        />
+        {error && (
+          <div className="mb-4 text-sm text-red-600 text-center">{error}</div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                Password
+              </label>
+              <a href="#" className="text-sm text-indigo-600 hover:text-indigo-500">
+                Forgot password?
+              </a>
+            </div>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            />
+          </div>
+          <div className="flex items-center">
+            <input
+              id="remember"
+              type="checkbox"
+              checked={rememberMe}
+              onChange={e => setRememberMe(e.target.checked)}
+              className="h-4 w-4 text-indigo-600 border-gray-300 rounded"
+            />
+            <label htmlFor="remember" className="ml-2 block text-sm text-gray-900">
+              Remember me
+            </label>
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-white text-sm font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;
+

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -1,0 +1,16 @@
+declare module '@supabase/supabase-js' {
+  export interface SignInWithPasswordCredentials {
+    email: string;
+    password: string;
+  }
+  export interface AuthResponse {
+    error: { message: string } | null;
+  }
+  export interface AuthApi {
+    signInWithPassword(credentials: SignInWithPasswordCredentials): Promise<AuthResponse>;
+  }
+  export interface SupabaseClient {
+    auth: AuthApi;
+  }
+  export function createClient(url: string, key: string, options?: unknown): SupabaseClient;
+}


### PR DESCRIPTION
## Summary
- add responsive Supabase-powered login page with remember me and forgot password link
- stub supabase types and add dependency

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b62a9db940832e8f482c22c1bd39be