### PR TITLE
feat: add supabase auth provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.542.0",
+    "@supabase/supabase-js": "^2.45.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/hooks/useSupabaseAuth.tsx
+++ b/src/hooks/useSupabaseAuth.tsx
@@ -1,15 +1,85 @@
-import { createContext, ReactNode, useContext } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  createClient,
+  SupabaseClient,
+  User,
+} from '@supabase/supabase-js';
 
-const SupabaseAuthContext = createContext(null);
+interface SupabaseAuthContextValue {
+  user: User | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  supabase: SupabaseClient;
+}
 
-export function SupabaseAuthProvider({ children }: { children: ReactNode }) {
+const SupabaseAuthContext =
+  createContext<SupabaseAuthContextValue | undefined>(undefined);
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export function SupabaseAuthProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const signIn = async (email: string, password: string) => {
+    await supabase.auth.signInWithPassword({ email, password });
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  const value: SupabaseAuthContextValue = {
+    user,
+    signIn,
+    signOut,
+    supabase,
+  };
+
   return (
-    <SupabaseAuthContext.Provider value={null}>
+    <SupabaseAuthContext.Provider value={value}>
       {children}
     </SupabaseAuthContext.Provider>
   );
 }
 
 export function useSupabaseAuth() {
-  return useContext(SupabaseAuthContext);
+  const context = useContext(SupabaseAuthContext);
+  if (!context) {
+    throw new Error(
+      'useSupabaseAuth must be used within a SupabaseAuthProvider',
+    );
+  }
+  return context;
 }
+
+export function useSupabaseClient() {
+  return useSupabaseAuth().supabase;
+}
+


### PR DESCRIPTION
## Summary
- add SupabaseAuthProvider and hooks for user auth
- add `@supabase/supabase-js` dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62d9502a8832eb06d2f89a724580e