### PR TITLE
fix: import DealCanvas and remove unused props

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,13 @@ import ErrorBoundary from './components/ErrorBoundary';
 import { Dashboard } from './components/Dashboard';
 import { CampaignInitialization } from './components/CampaignInitialization';
 import { Navbar } from './components/Navbar';
-import DeliverableTable from './components/DeliverableTable';
+import DealCanvas from './components/DealCanvas';
 import { MediaSummary } from './components/MediaSummary';
 import { PriceTransparencyPanel } from './components/PriceTransparencyPanel';
 import { useMediaSummaryData } from './hooks/useMediaSummaryData';
 import { calculateScenarioMetrics, formatCurrency } from './utils/calculations';
 import { exportToCsv } from './utils/export';
-import { Campaign } from './types/campaign';
+import { Campaign, DeliverableRow, PlanningMode } from './types/campaign';
 import { sampleDeliverables, sampleCampaigns } from './utils/mockData';
 
 function App() {
@@ -50,8 +50,6 @@ function App() {
     selectedRowId,
     selectedRowIds,
     setPlanningMode,
-    updateDeliverable,
-    toggleExpanded,
     addDeliverable,
     addChildDeliverable,
     deleteDeliverable,
@@ -174,8 +172,6 @@ function App() {
             <div className="lg:col-span-2 space-y-6 min-h-0">
               <DealCanvas
                 deliverables={deliverables}
-                onUpdate={updateDeliverable}
-                onToggleExpanded={toggleExpanded}
                 onAddChild={addChildDeliverable}
                 onAddRow={addDeliverable}
                 onDeleteRow={deleteDeliverable}

--- a/src/components/DealCanvas.tsx
+++ b/src/components/DealCanvas.tsx
@@ -6,8 +6,6 @@ import { BulkEditModal } from './BulkEditModal';
 
 interface DealCanvasProps {
   deliverables: DeliverableRow[];
-  onUpdate: (id: string, updates: Partial<DeliverableRow>) => void;
-  onToggleExpanded: (id: string) => void;
   onAddChild: (parentId: string) => void;
   onAddRow: () => void;
   onDeleteRow: (id: string) => void;
@@ -20,8 +18,6 @@ interface DealCanvasProps {
 
 const DealCanvas: React.FC<DealCanvasProps> = ({
   deliverables,
-  onUpdate,
-  onToggleExpanded,
   onAddChild,
   onAddRow,
   onDeleteRow,
@@ -32,11 +28,9 @@ const DealCanvas: React.FC<DealCanvasProps> = ({
   onMaterializeCohort,
 }) => {
   const [isBulkEditOpen, setIsBulkEditOpen] = React.useState(false);
-  const [editingDeliverableId, setEditingDeliverableId] = React.useState<string | null>(null);
   const hasSelection = selectedRowIds.length > 0;
 
   const handleEditDeliverable = (id: string) => {
-    setEditingDeliverableId(id);
     // TODO: Open inline editor or modal for editing deliverable details
     console.log('Edit deliverable:', id);
   };


### PR DESCRIPTION
## Summary
- import DealCanvas in App and wire it up
- drop unused DealCanvas props and cleanup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6dc8a0ea0832e9452db3c0fe917d9