### PR TITLE
refactor: rely on Tailwind fade-in keyframes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,11 +2,3 @@
 @tailwind components;
 @tailwind utilities;
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}


### PR DESCRIPTION
## Summary
- remove manual `@keyframes fadeIn` definition
- defer fade-in animation to Tailwind's config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `rg -o '@keyframes fadeIn' dist/assets/index-F_9kzFui.css`


------
https://chatgpt.com/codex/tasks/task_e_68b723ab40dc832e9d6cf934cb85a187