### PR TITLE
Use crypto UUIDs for deliverable identifiers

### DIFF
--- a/src/components/CampaignInitialization.tsx
+++ b/src/components/CampaignInitialization.tsx
@@ -148,7 +148,7 @@ export const CampaignInitialization: React.FC<CampaignInitializationProps> = ({
     setErrors(stepErrors);
     if (Object.keys(stepErrors).length === 0) {
       const completeCampaign: Campaign = {
-        id: existingCampaign?.id || Math.random().toString(36).substr(2, 9),
+        id: existingCampaign?.id || crypto.randomUUID(),
         name: campaign.name!,
         client: campaign.client!,
         brand: campaign.brand!,

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,4 +1,5 @@
-import { DeliverableRow, CalculationMetrics, AdminConfiguration, Rights } from '../types/campaign';
+import { DeliverableRow, CalculationMetrics, AdminConfiguration, Rights, Creator } from '../types/campaign';
+import { createMockDeliverable } from './mockData';
 
 // Mock admin configuration - in production this would come from API
 const adminConfig: AdminConfiguration = {
@@ -275,19 +276,25 @@ export const materializeCohort = (
   cohortRow: DeliverableRow,
   specificCreators: Creator[]
 ): DeliverableRow[] => {
-  return specificCreators.map((creator, index) => ({
-    ...cohortRow,
-    id: `${cohortRow.id}_materialized_${index}`,
-    creatorType: 'specific' as const,
-    creatorInfo: { ...creator, parentCohortId: cohortRow.id },
-    cohortSize: undefined,
-    quantity: cohortRow.quantity, // Each creator gets the same deliverable quantity
-    unitFee: creator.baseRate,
-    baseRate: creator.baseRate,
-    isMaterialized: true,
-    estimatedViews: Math.round(creator.followers * 0.1), // 10% reach estimate
-    estimatedEngagements: Math.round(creator.followers * creator.engagementRate / 100),
-  }));
+  return specificCreators.map((creator) => {
+    const baseProps: Partial<DeliverableRow> = { ...cohortRow };
+    delete baseProps.id;
+    delete baseProps.children;
+    return createMockDeliverable({
+      ...baseProps,
+      creatorType: 'specific',
+      creatorInfo: { ...creator, parentCohortId: cohortRow.id },
+      cohortSize: undefined,
+      quantity: cohortRow.quantity, // Each creator gets the same deliverable quantity
+      unitFee: creator.baseRate,
+      baseRate: creator.baseRate,
+      isMaterialized: true,
+      rights: { ...cohortRow.rights },
+      estimatedViews: Math.round(creator.followers * 0.1), // 10% reach estimate
+      estimatedEngagements: Math.round(creator.followers * creator.engagementRate / 100),
+      children: [],
+    });
+  });
 };
 
 export const formatCurrency = (amount: number): string => {

--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -129,7 +129,7 @@ export const deliverableBundles: DeliverableBundle[] = [
 ];
 
 export const createMockDeliverable = (overrides: Partial<DeliverableRow> = {}): DeliverableRow => ({
-  id: Math.random().toString(36).substr(2, 9),
+  id: crypto.randomUUID(),
   type: 'organic',
   platform: 'instagram',
   deliverableType: 'Post',


### PR DESCRIPTION
## Summary
- replace ad-hoc `Math.random` id generation with `crypto.randomUUID` in mock deliverable builder
- ensure cohort materialization and new campaigns rely on the central id generator

## Testing
- `node -e "const ids=[...Array(1000)].map(()=>crypto.randomUUID()); console.log('unique', new Set(ids).size === ids.length);"`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b72bc61f50832e8432ff2d21223de3